### PR TITLE
Deserializer out of memory fix

### DIFF
--- a/app/src/main/java/com/aconno/blesniffer/adapter/DeserializerEditorAdapter.kt
+++ b/app/src/main/java/com/aconno/blesniffer/adapter/DeserializerEditorAdapter.kt
@@ -44,11 +44,18 @@ class DeserializerEditorAdapter(
             fieldDeserializers.maxBy {
                 it.endIndexExclusive
             }?.let {
-                this.startIndexInclusive = it.endIndexExclusive
-                this.endIndexExclusive = this.startIndexInclusive + this.type.converter.length
+                setFieldDeserializerIndices(this, it.endIndexExclusive)
+                if(this.endIndexExclusive > MAX_DESERIALIZER_FIELD_END_INDEX) {
+                    setFieldDeserializerIndices(this,0)
+                }
             }
         })
         notifyItemInserted(fieldDeserializers.size - 1)
+    }
+
+    private fun setFieldDeserializerIndices(deserializerField : FieldDeserializer, startIndex : Int) {
+        deserializerField.startIndexInclusive = startIndex
+        deserializerField.endIndexExclusive = startIndex + deserializerField.type.converter.length
     }
 
     override fun getItemCount(): Int {
@@ -207,4 +214,7 @@ class DeserializerEditorAdapter(
             }
         }
 
+    companion object {
+        const val MAX_DESERIALIZER_FIELD_END_INDEX = 99999
+    }
 }

--- a/app/src/main/res/layout-port/item_deserializer_field.xml
+++ b/app/src/main/res/layout-port/item_deserializer_field.xml
@@ -71,7 +71,8 @@
             android:layout_height="wrap_content"
             android:ems="3"
             android:hint="@string/start_index_inclusive"
-            android:inputType="number" />
+            android:inputType="number"
+            android:maxLength="5"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -88,7 +89,8 @@
             android:layout_height="wrap_content"
             android:ems="3"
             android:hint="@string/end_index_inclusive"
-            android:inputType="number" />
+            android:inputType="number"
+            android:maxLength="5"/>
     </com.google.android.material.textfield.TextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_deserializer_field.xml
+++ b/app/src/main/res/layout/item_deserializer_field.xml
@@ -55,7 +55,8 @@
             android:layout_height="wrap_content"
             android:ems="3"
             android:hint="@string/start_index_inclusive"
-            android:inputType="number" />
+            android:inputType="number"
+            android:maxLength="5"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -72,7 +73,8 @@
             android:layout_height="wrap_content"
             android:ems="3"
             android:hint="@string/end_index_inclusive"
-            android:inputType="number" />
+            android:inputType="number"
+            android:maxLength="5"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <ImageButton


### PR DESCRIPTION
Set field deserializer end index size limit in order to prevent out of memory error caused by too large end indices.