### PR TITLE
Hex formatter refactor

### DIFF
--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/HexEditController.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/HexEditController.kt
@@ -39,14 +39,11 @@ class HexEditController(private val view : IHexEditView) : HexContentListener,
 
     fun onViewContentChanged() {
         val content = view.getContent()
-        val parsedValues = try {
-            formatter.parse(view.getContent())
-        } catch (ex : IncompatibleFormatException) {
-            loadValuesFromText(content)
-            return
-        }
+        val parsedValues = formatter.parse(view.getContent())
 
-        if(!formatter.areValuesDerivableFrom(parsedValues,model.getValues())) {
+        if(parsedValues == null) {
+            loadValuesFromText(content)
+        } else if(!formatter.areValuesDerivableFrom(parsedValues,model.getValues())) {
             model.setValues(parsedValues)
         }
     }

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/BytePairsHexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/BytePairsHexFormatter.kt
@@ -17,7 +17,7 @@ class BytePairsHexFormatter : HexFormatter {
         return builder.trim().toString()
     }
 
-    override fun parse(text: String): List<Char> {
+    override fun parse(text: String): List<Char>? {
         return HexFormattersUtils.parseGroupedHexBytes(text,2)
     }
 

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/HexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/HexFormatter.kt
@@ -2,7 +2,7 @@ package com.aconno.hexinputlib.formatter
 
 interface HexFormatter {
     fun format(values : List<Char>) : String
-    fun parse(text : String) : List<Char>
+    fun parse(text : String) : List<Char>?
     fun locateSourceValue(values : List<Char>, formattedValueIndex : Int) : Int
     fun locateFormattedValue(values : List<Char>, sourceIndex : Int) : Int
     fun areValuesDerivableFrom(values : List<Char>, fromValues : List<Char>) : Boolean

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/HexFormatters.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/HexFormatters.kt
@@ -17,12 +17,7 @@ object HexFormatters {
         FormatterType.values().forEach {
             val formatter = getFormatter(it)
 
-            val parsedValues = try {
-                    formatter.parse(formattedContent)
-                } catch (ex : IncompatibleFormatException) {
-                    null
-                }
-
+            val parsedValues = formatter.parse(formattedContent)
             if(parsedValues != null) {
                 return parsedValues
             }

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/HexFormattersUtils.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/HexFormattersUtils.kt
@@ -5,7 +5,7 @@ import com.aconno.hexinputlib.isHexChar
 object HexFormattersUtils {
     private const val HEX_CHARS_PER_BYTE = 2
 
-    fun parseGroupedHexBytes(text : String, expectedGroupSizeInBytes : Int) : List<Char> {
+    fun parseGroupedHexBytes(text : String, expectedGroupSizeInBytes : Int) : List<Char>? {
         val expectedGroupSizeInChars = expectedGroupSizeInBytes * HEX_CHARS_PER_BYTE
         val values = mutableListOf<Char>()
 
@@ -16,7 +16,7 @@ object HexFormattersUtils {
                 part.any { !it.isHexChar() }
             ) {
 
-                throw IncompatibleFormatException()
+                return null
             }
             part.forEach { values.add(it) }
         }
@@ -24,10 +24,10 @@ object HexFormattersUtils {
         return values
     }
 
-    fun parsePlainValues(text: String) : List<Char> {
+    fun parsePlainValues(text: String) : List<Char>? {
         val trimmedText = text.trim()
         if(trimmedText.find { !it.isHexChar() } != null) {
-            throw IncompatibleFormatException()
+            return null
         }
         return trimmedText.toCharArray().toList()
     }

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/MacAddressHexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/MacAddressHexFormatter.kt
@@ -16,9 +16,9 @@ class MacAddressHexFormatter : HexFormatter {
         }.toString()
     }
 
-    override fun parse(text: String): List<Char> {
+    override fun parse(text: String): List<Char>? {
         if(!isFormatCompatible(text)) {
-            throw IncompatibleFormatException()
+            return null
         }
         return HexFormattersUtils.parseGroupedHexBytes(text.replace(":"," "),1) //replacing all ':' with space gives text in format of grouped hex bytes with group size of 1 byte
     }

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/PlainByteHexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/PlainByteHexFormatter.kt
@@ -6,7 +6,7 @@ class PlainByteHexFormatter : HexFormatter {
         return HexFormattersUtils.hexValuesToValuePairs(values).joinToString("")
     }
 
-    override fun parse(text: String): List<Char> {
+    override fun parse(text: String): List<Char>? {
         return HexFormattersUtils.parsePlainValues(text)
     }
 

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/PlainValuesHexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/PlainValuesHexFormatter.kt
@@ -6,7 +6,7 @@ class PlainValuesHexFormatter : HexFormatter {
         return values.joinToString("")
     }
 
-    override fun parse(text: String): List<Char> {
+    override fun parse(text: String): List<Char>? {
         return HexFormattersUtils.parsePlainValues(text)
     }
 

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/PrefixedByteHexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/PrefixedByteHexFormatter.kt
@@ -13,24 +13,25 @@ class PrefixedByteHexFormatter : HexFormatter {
         return valuePairs.joinToString(" 0x","0x")
     }
 
-    override fun parse(text: String): List<Char> {
+    override fun parse(text: String): List<Char>? {
         val values = mutableListOf<Char>()
         val textParts =
             text.toUpperCase(Locale.ROOT).split(" ").filter { it.isNotEmpty() && it.isNotBlank() }
 
         for((index,part) in textParts.withIndex()) {
-            values.addAll(parsePart(part,index==0,index==textParts.lastIndex))
+            val textPartValues = parsePart(part,index==0,index==textParts.lastIndex) ?: return null
+            values.addAll(textPartValues)
         }
 
         return values
     }
 
-    private fun parsePart(part : String, acceptIncompleteStart : Boolean, acceptIncompleteEnd : Boolean) : List<Char> {
+    private fun parsePart(part : String, acceptIncompleteStart : Boolean, acceptIncompleteEnd : Boolean) : List<Char>? {
         if(!acceptIncompleteStart && (part.first() != '0' || part.length > 1 && part[1] != 'X') ) {
-            throw IncompatibleFormatException()
+            return null
         }
         if(!acceptIncompleteEnd && (!part.last().isHexChar() || part.length > 1 && !part[part.lastIndex - 1].isHexChar()) ) { //checking if end is complete: the last char has to be a hex char and second to last char (if included) also has to be a hex char
-            throw IncompatibleFormatException()
+            return null
         }
         val prefixLength = when {
             part.startsWith("0X") -> 2
@@ -40,7 +41,7 @@ class PrefixedByteHexFormatter : HexFormatter {
 
         val values = part.subSequence(prefixLength,part.length)
         if(values.any { !it.isHexChar() }) {
-            throw IncompatibleFormatException()
+            return null
         }
         return values.toList()
     }

--- a/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/SingleByteHexFormatter.kt
+++ b/hexinputlib/src/main/java/com/aconno/hexinputlib/formatter/SingleByteHexFormatter.kt
@@ -6,7 +6,7 @@ class SingleByteHexFormatter : HexFormatter {
         return HexFormattersUtils.hexValuesToValuePairs(values).joinToString(" ")
     }
 
-    override fun parse(text: String): List<Char> {
+    override fun parse(text: String): List<Char>? {
         return HexFormattersUtils.parseGroupedHexBytes(text,1)
     }
 


### PR DESCRIPTION
Refactored hex formatters to return null instead of throwing incompatible format exception when parsing formatted content.